### PR TITLE
Correct diff-highlight color also color diff-index and separator

### DIFF
--- a/colors/molokai-like-theme.tigrc
+++ b/colors/molokai-like-theme.tigrc
@@ -65,8 +65,8 @@ color "Commit: "        			141         default
 color "CommitDate: "    			67          default
 color "Merge: "         			161         default
 color diff-stat         			166         234
-color diff-add-highlight 			2       	default
-color diff-del-highlight 			1       	default
+color diff-add-highlight 			default     24
+color diff-del-highlight 			162         53
 
 ## Signature colors
 color "gpg: "                       23			default

--- a/colors/molokai-like-theme.tigrc
+++ b/colors/molokai-like-theme.tigrc
@@ -64,6 +64,8 @@ color "AuthorDate: "    			67          default
 color "Commit: "        			141         default
 color "CommitDate: "    			67          default
 color "Merge: "         			161         default
+color "---"              			67          default
+color diff-index            			67          default
 color diff-stat         			166         234
 color diff-add-highlight 			default     24
 color diff-del-highlight 			162         53


### PR DESCRIPTION
Hi,

The diff-highlight will not affect when the color is:

color diff-add-highlight 			2       	default
color diff-del-highlight 			1       	default

Correct it by the color in molokai.vim.

Also the default color of index and separator is dark blue. Color it to make eye friendly.

Thanks.